### PR TITLE
Migrar acta fundacional desde antiguo repo hg.

### DIFF
--- a/acta-2013-01-22-fundacional.rst
+++ b/acta-2013-01-22-fundacional.rst
@@ -1,0 +1,130 @@
+ACTA FUNDACIONAL
+----------------
+
+Reunidos en Madrid, el día 22 de Enero de 2013,
+a las 21:00 horas, las personas que a continuación se detallan:
+
+.. list-table::
+  :widths: 15, 7, 30, 7, 7
+  :header-rows: 1
+
+  * - Nombre
+    - Nacionalidad
+    - Domicilio
+    - N.I.F.
+    - Firma
+  * - Francesc Josep Alted Abad
+    - Española
+    - *CONFIDENCIAL*, Castelló de la Plana, España
+    - *CONFIDENCIAL*
+    -
+  * - Antoni Aloy López
+    - Española
+    - *CONFIDENCIAL*, Illes balears, España
+    - *CONFIDENCIAL*
+    -
+  * - Juan Luis Cano Rodríguez
+    - Española
+    - *CONFIDENCIAL*, Milano, Italia
+    - *CONFIDENCIAL*
+    -
+  * - Enrique Porta Caramés
+    - Española
+    - *CONFIDENCIAL*, Valencia, España
+    - *CONFIDENCIAL*
+    -
+  * - Jesús Cea Avión
+    - Española
+    - *CONFIDENCIAL* Vigo. Pontevedra.
+    - *CONFIDENCIAL*
+    -
+  * - Yamila Moreno Suárez
+    - Española
+    - *CONFIDENCIAL*, Madrid, España
+    - *CONFIDENCIAL*
+    -
+  * - Raúl Cumplido Domínguez
+    - Española
+    - *CONFIDENCIAL*, Barcelona, España
+    - *CONFIDENCIAL*
+    -
+  * - Juan Riaza Montes
+    - Española
+    - *CONFIDENCIAL*, Burgos, España
+    - *CONFIDENCIAL*
+    -
+  * - Juan Ignacio Rodríguez de León
+    - Española
+    - *CONFIDENCIAL* Tenerife / Islas Canarias, España
+    - *CONFIDENCIAL*
+    -
+  * - Francisco Correoso García
+    - Española
+    - *CONFIDENCIAL*, Madrid, España
+    - *CONFIDENCIAL*
+    -
+  * - Andrey Antukh
+    - Rusa
+    - *CONFIDENCIAL*, Madrid, España
+    - *CONFIDENCIAL*
+    -
+  * - Fernando Jesús Salamero Pelay
+    - Española
+    - *CONFIDENCIAL*, Huesca, España
+    - *CONFIDENCIAL*
+    -
+  * - Jesús Espino García
+    - Española
+    - *CONFIDENCIAL*, Madrid, España
+    - *CONFIDENCIAL*
+    -
+  * - Alberto Chamorro Ruiz
+    - Española
+    - *CONFIDENCIAL*, Madrid, España
+    - *CONFIDENCIAL*
+    -
+  * - Pablo Lobariñas Criserá
+    - Española
+    - *CONFIDENCIAL*, Madrid, España
+    - *CONFIDENCIAL*
+    -
+
+Acuerdan:
+
+1. Constituir una asociación al amparo de la Ley Orgánica 1/2002, de 22 de
+   marzo, reguladora del Derecho de Asociación que se denominará "Python
+   España".
+
+2. Aprobar los Estatutos que se incorporan a este Acta Fundacional como anexo y
+   cuyo documento en formato rst tiene como suma de verificación sha1
+   b37d1beafcef7f75138a9502f329d5215d452356, por los que se va a regir la
+   entidad, que fueron leídos en este mismo acto y aprobados por unanimidad de
+   los reunidos.
+
+3. Aprobar reglamento interno que se incorporan a este Acta Fundacional como
+   anexo y cuyo documento en formato rst tiene como suma de verificación sha1
+   9171d3728ee11c838881cbd592b2b4ca6519f56f, que fue leído en este mismo
+   acto y aprobado por unanimidad de los reunidos.
+
+4. Designar a la Junta Directiva de la entidad, cuya composición es la siguiente:
+
+- Presidente: Pablo Lobariñas
+- Vicepresidente: Jesús Cea Avión
+- Secretario: Jesús Espino García
+- Tesorero: Andrey Antukh
+- Vocales: Yamila Moreno Suárez, Juan Riaza Montes, Enrique Porta Caramés, Juan
+  Luis Cano Rodríguez, Francisco Correoso García, Raúl Cumplido Domínguez,
+  Fernando Jesús Salamero Pelay
+
+5. Consentir a la Administración encargada de la inscripción registral para que
+   sean comprobados los datos de identidad de los firmantes. (Real Decreto
+   522/2006, de 28 de abril - B.O.E. núm. 110, de 9 de mayo de 2006).
+
+Y sin más asuntos que tratar se levanta la sesión, siendo las 21:30 horas del día de la
+fecha.
+
+.. note::
+
+   El hash SHA1 del acta original es
+   :kbd:`005e003541ca3e750a4ef3f01cfd6701595cd4dd`.
+

--- a/acta-2013-01-22-fundacional.rst
+++ b/acta-2013-01-22-fundacional.rst
@@ -97,13 +97,13 @@ Acuerdan:
 
 2. Aprobar los Estatutos que se incorporan a este Acta Fundacional como anexo y
    cuyo documento en formato rst tiene como suma de verificación sha1
-   b37d1beafcef7f75138a9502f329d5215d452356, por los que se va a regir la
+   b37d1beafcef7f75138a9502f329d5215d452356¹, por los que se va a regir la
    entidad, que fueron leídos en este mismo acto y aprobados por unanimidad de
    los reunidos.
 
 3. Aprobar reglamento interno que se incorporan a este Acta Fundacional como
    anexo y cuyo documento en formato rst tiene como suma de verificación sha1
-   9171d3728ee11c838881cbd592b2b4ca6519f56f, que fue leído en este mismo
+   9171d3728ee11c838881cbd592b2b4ca6519f56f¹, que fue leído en este mismo
    acto y aprobado por unanimidad de los reunidos.
 
 4. Designar a la Junta Directiva de la entidad, cuya composición es la siguiente:
@@ -128,3 +128,4 @@ fecha.
    El hash SHA1 del acta original es
    :kbd:`005e003541ca3e750a4ef3f01cfd6701595cd4dd`.
 
+¹ Estos hashes sha1 ya no son válidos ya que los documentos se han copiado desde las fuentes originales, pero los mantenemos en el documento para no alterarlo.


### PR DESCRIPTION
http://documentos-asociacion.es.python.org/actas/acta-2013-01-22-fundacional.html

El archivo estaba vacío por alguna razón. Luego había un duplicado también vacío que se ha eliminado.